### PR TITLE
Fix windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,19 @@ To build this module, you need MIT Kerberos library. Refer to the section corres
   brew install krb5
   npm install krb5
   ```
+* Windows
+  ```
+  choco install mitkerberos --install-arguments="ADDLOCAL=all"
+  npm install krb5
+  ```
 
 Python 2 must be available in your path. You can check it by running `python --version`. It should something like "Python 2.7.16". If not, you must ensure that python 2 is used, for by placing back the original path: `PATH="/usr/bin:$PATH" npm install`.
 
 ### Windows
 
-To compile this library in windows, you need a complete visual studio compile chain, please refer to the [node-gyp instructions](https://github.com/nodejs/node-gyp#on-windows). If you have a 32 bit OS, please delete `binding.gyp` and rename `_binding32.gyp` before install.
+To compile this library on windows, you need a complete visual studio compile chain, please refer to the [node-gyp instructions](https://github.com/nodejs/node-gyp#on-windows). If you have a 32 bit OS, please delete `binding.gyp` and rename `_binding32.gyp` before install.
+
+To install the kerberos headers needed for the build, you need to tick the "SDK" options. It is disabled by default.
 
 ### z/OS
 

--- a/src/base64.cc
+++ b/src/base64.cc
@@ -60,7 +60,7 @@ void encode64 (char *orig, char *dest, int nbcar){
 
 int decode64(char *buffer) {
   int  car;        // caractère du fichier
-  char valcar [4]; // valeur après conversion des caractères
+  char valcar[4] = {0, 0, 0, 0}; // valeur après conversion des caractères
   int  i;          // compteur
   int  posorig;    // position dans la ligne passée en paramètre
   int  posdest;    // position dans la nouvelle ligne générée

--- a/src/gss_bind.h
+++ b/src/gss_bind.h
@@ -3,14 +3,7 @@
 #include <gssapi.h>
 #include <gssapi/gssapi_krb5.h>
 #include <string>
+
 #include "base64.h"
-//For debug
-#include <iostream>
-#include <assert.h>
-#include <unistd.h>
-#include <sys/types.h>
-#ifndef __MVS__
-#include <sys/syscall.h>
-#endif
 
 Napi::Value _generate_spnego_token(const Napi::CallbackInfo& info);

--- a/src/krb5_bind.cc
+++ b/src/krb5_bind.cc
@@ -10,7 +10,7 @@
 class Worker_krb5_build_principal : public Napi::AsyncWorker {
   public:
     Worker_krb5_build_principal(krb5_context ctx,
-                                uint rlen,
+                                uint32_t rlen,
                                 std::string realm,
                                 std::string user,
                                 Napi::Function& callback)
@@ -56,7 +56,7 @@ class Worker_krb5_build_principal : public Napi::AsyncWorker {
 
     // In parameters
     krb5_context context;
-    uint rlen;
+    uint32_t rlen;
     std::string realm;
     std::string user;
 
@@ -72,7 +72,7 @@ Napi::Value _krb5_build_principal(const Napi::CallbackInfo& info) {
   }
 
   krb5_context krb_context = info[0].As<Napi::External<struct _krb5_context>>().Data();
-  uint rlen = info[1].As<Napi::Number>().Uint32Value();
+  uint32_t rlen = info[1].As<Napi::Number>().Uint32Value();
   std::string realm = info[2].As<Napi::String>().Utf8Value();
   std::string user = info[3].As<Napi::String>().Utf8Value();
   Napi::Function callback = info[4].As<Napi::Function>();

--- a/src/krb5_bind.h
+++ b/src/krb5_bind.h
@@ -1,14 +1,7 @@
 #include <napi.h>
 #include <krb5.h>
 #include <string>
-//For debug
-#include <iostream>
-#include <assert.h>
-#include <unistd.h>
-#include <sys/types.h>
-#ifndef __MVS__
-#include <sys/syscall.h>
-#endif
+#include <cstdint>
 
 Napi::Value _krb5_build_principal(const Napi::CallbackInfo& info);
 Napi::Value _krb5_cc_close(const Napi::CallbackInfo& info);

--- a/src/krb5_zos.h
+++ b/src/krb5_zos.h
@@ -2,8 +2,6 @@
 #define KRB5_ZOS_H_
 #include <_Nascii.h>
 
-typedef u_int uint;
-
 class __ae_runmode {
   int mode;
 


### PR DESCRIPTION
Removed the debug includes that made the windows build fail
Replaced the include <sys/types.h> with the std one <cstdint>, standard C++11 (Node-gyp requires at least C++11 for nodejs14, and at least C++14 for nodejs16)
ADD Windows build information

ADD stack array initialization in src/base64.cc to remove warnings