### PR TITLE
Add a vagrant windows virtual machine example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .vscode
 package-lock.json
 yarn.lock
+.vagrant/

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,22 @@
+vm_name = "windows-host1"
+
+Vagrant.configure("2") do |config|
+    config.vm.box = "gusztavvargadr/windows-10"
+    config.vm.define vm_name
+    config.vm.network "private_network", ip: "192.168.64.100"
+    config.vm.communicator = "winrm"
+    config.winrm.transport = :plaintext
+
+    config.vm.provider "virtualbox" do |v|
+        v.name = vm_name
+        v.memory = 8192
+        v.cpus = 6
+    end
+      
+    config.vm.provision :ansible do |ansible|
+        ansible.playbook = "provision.yaml"
+        ansible.host_vars = {
+            vm_name => { "ansible_winrm_scheme" => "http" }
+        }
+    end
+  end

--- a/vagrant/provision.yaml
+++ b/vagrant/provision.yaml
@@ -1,0 +1,32 @@
+---
+- hosts: '*'
+
+  tasks:
+
+    - name: Install VS 2017 with native workload
+      win_chocolatey:
+        name: "{{ item }}"
+        state: present
+      loop: # Put in a loop otherwise it's run concurrently
+        - visualstudio2017community
+        - visualstudio2017-workload-nativedesktop
+
+    - name: Install dev dependencies
+      win_chocolatey:
+        name:
+        - python
+        - nodejs
+        - git
+        state: present
+    
+    - name: Install MIT Kerberos 4.1
+      win_chocolatey:
+        name: mitkerberos
+        state: present
+        install_args: ADDLOCAL=all
+    
+    - name: Configure npm MSVS
+      win_shell: npm config set msvs_version 2017
+
+    - name: Clone krb5 folder
+      win_shell: git clone https://github.com/adaltas/node-krb5 /node-krb5


### PR DESCRIPTION
This PR adds a virtual machine using Vagrant provisioned with Ansible. It can be used as an example regarding the dev dependencies needed for windows users.

It installs a Visual Studio 2017 with native workloads which means you can use VS to edit the code inside the VM.