### PR TITLE
Add github actions as CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         os: ["archlinux", "centos7", "ubuntu"]
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build-linux"
+  build-linux:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: ["archlinux", "centos7", "ubuntu"]
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Build and run tests
+        run: cd docker && ./run_tests.sh ${{ matrix.os }}
+

--- a/docker/rest/Dockerfile
+++ b/docker/rest/Dockerfile
@@ -4,8 +4,7 @@ FROM centos:7
 RUN yum install -y epel-release
 
 # Python 3
-RUN yum install -y https://repo.ius.io/ius-release-el7.rpm
-RUN yum update -y && yum install -y python36u python36u-libs python36u-devel python36u-pip
+RUN yum update -y && yum install -y python3 python3-libs python3-devel python3-pip
 
 # Install misc
 RUN yum install -y wget git vim sudo gcc
@@ -13,8 +12,8 @@ RUN yum install -y wget git vim sudo gcc
 # Install Kerberos
 RUN yum install -y krb5-devel krb5-workstation
 
-RUN pip3.6 install --upgrade pip
-RUN pip3.6 install gssapi
+RUN pip3 install --upgrade pip
+RUN pip3 install gssapi
 
 RUN mkdir -p /node-krb5
 COPY ./run.sh /run.sh


### PR DESCRIPTION
This is a sample CI, executing docker tests on all 3 target OS (archlinux, centos7, Ubuntu).

If want to use this also as a CD, we could add the following:

In the event section:
```
on:
  release:
    types:
      - created
```

And then add a job with the condition:
```
if: github.event_name == 'release' && github.event.action == 'created'
```
