### PR TITLE
Enable Windows build in Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,3 +30,26 @@ jobs:
       - name: Build and run tests
         run: cd docker && ./run_tests.sh ${{ matrix.os }}
 
+  build-windows:
+    # The type of runner that the job will run on
+    name: "Windows Latest"
+    runs-on: windows-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Error 3010 means reboot, therefore we ignore it since we only require the headers and libs
+      - name: Install MIT kerberos
+        run: choco install -y --limit-output mitkerberos --ia=ADDLOCAL=all --ignore-package-exit-codes
+        
+      - name: Get MIT Kerberos path
+        run: |
+          $krb_path=(Get-ItemProperty -Path 'HKLM:/SOFTWARE/MIT/Kerberos/SDK/4.1.0').PathName.replace('\', '/')
+          Write-Host "::set-output name=KRB_PATH::$krb_path"
+        id: mit_kerberos
+
+      - name: Build on windows
+        run: npm install
+        env:
+          GYP_DEFINES: KRB_PATH='${{ steps.mit_kerberos.outputs.KRB_PATH }}'

--- a/binding.gyp
+++ b/binding.gyp
@@ -16,7 +16,7 @@
                 "OS=='win'",
                 {
                     "variables": {
-                        "KRB_PATH": "/Program Files/MIT/Kerberos"
+                        "KRB_PATH%": "/Program Files/MIT/Kerberos"
                     },
                     "include_dirs": ["<(KRB_PATH)/include", "<(KRB_PATH)/include/gssapi", "src"],
                     "conditions": [


### PR DESCRIPTION
This PR enables windows build job in Github Actions.

No tests are performed since we do not have any windows tests