### PR TITLE
Bump dependency "node-addon-api" from 1.7.1 to 1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "dependencies": {
     "bindings": "1.5.0",
-    "node-addon-api": "1.7.1"
+    "node-addon-api": "1.7.2"
   },
   "devDependencies": {
     "coffeescript": "2.4.1",


### PR DESCRIPTION
Bump the dependency Bump dependency "node-addon-api" from 1.7.1 to 1.7.2, because of CSVs found and rated "high" for the 1.7.1 version. Sole change is in the package.json. The specific CVE is labelled: `CVE-2020-8174`.